### PR TITLE
添加”唤醒词与结束词“模式

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3781,6 +3781,7 @@ if ('serviceWorker' in navigator) {
                           <el-option :label="t('auto')" value="auto" ></el-option>
                           <el-option :label="t('manual')" value="manual" ></el-option>
                           <el-option :label="t('wakeWord')" value="wakeWord" ></el-option>
+                          <el-option :label="t('wakeWordAndEndWord')" value="wakeWordAndEndWord" ></el-option>
                           <el-option :label="t('keyTriggered')" value="keyTriggered" ></el-option>
                         </el-select>
                       </el-form-item>

--- a/static/js/locales.js
+++ b/static/js/locales.js
@@ -525,6 +525,7 @@ const translations = {
         'auto':'自动',
         'manual': '手动',
         'wakeWord': '唤醒词',
+        'wakeWordAndEndWord': '唤醒词与结束词',
         'wakeWordMode': '唤醒词：开启唤醒词模式后可用，只有带唤醒词的消息才会被识别并发送',
         'wakeWordPlaceholder': '请输入唤醒词',
         'hotkey': '快捷键：按下时录音，松开时自动发送',

--- a/static/js/vue_data.js
+++ b/static/js/vue_data.js
@@ -455,7 +455,8 @@ let vue_data = {
       interactionMethod: "auto",
       hotkey : "Alt",
       wakeWord: "小派",
-      hotwords: "小派 80\nagent party 60",
+      endWord: "结束对话",
+      hotwords: "小派 80\nagent party 60\n结束对话 80",
     },
     supportedLanguages: [
       { code: 'zh-CN', name: '中文' },
@@ -1577,4 +1578,5 @@ main();`,
     textInputOptions: [], // 确保这里是一个空数组
     imageInputOptions: [], // 确保这里是一个空数组
     seedInputOptions: [], // 确保这里是一个空数组
+    inAutoMode: false, // 内存变量，不在设置中保存
 };

--- a/static/js/vue_methods.js
+++ b/static/js/vue_methods.js
@@ -383,6 +383,7 @@ let vue_methods = {
           m.briefly = false;
         })
       }
+      this.inAutoMode = false; // 重置自动模式状态
       this.scrollToBottom();
       await this.autoSaveSettings();
     },
@@ -1999,6 +2000,7 @@ let vue_methods = {
       this.fileLinks = [];
       this.isThinkOpen = false; // 重置思考模式状态
       this.asyncToolsID = [];
+      this.inAutoMode = false; // 重置自动模式状态
       this.randomGreetings(); // 重新生成随机问候语
       this.scrollToBottom();    // 触发界面更新
       this.autoSaveSettings();
@@ -4963,6 +4965,39 @@ let vue_methods = {
               this.openWakeWindow();           // 进入 30s 免唤醒
             } else {
               this.userInput = '';             // 未唤醒，清空输入
+            }
+          }
+          
+          if (this.asrSettings.interactionMethod == "wakeWordAndEndWord") {
+            const userInputLower = this.userInput.toLowerCase();
+            const wakeWordLower = this.asrSettings.wakeWord.toLowerCase();
+            const endWordLower = this.asrSettings.endWord.toLowerCase();
+            
+            // 检查是否包含结束词
+            if (userInputLower.includes(endWordLower)) {
+              this.inAutoMode = false;
+              console.log('End word detected, exiting auto mode');
+              // 可以选择发送包含结束词的消息，或者清空不发送
+              this.userInput = '';
+            }
+            // 检查是否包含唤醒词
+            else if (userInputLower.includes(wakeWordLower)) {
+              this.inAutoMode = true;
+              console.log('ake word detected, entering auto mode');
+              // 发送包含唤醒词的消息
+              if (this.ttsSettings.enabledInterruption) {
+                this.sendMessage();
+              } else if (!this.TTSrunning ||  !this.ttsSettings.enabled) {
+                this.sendMessage();
+              }
+            }
+            // 如果在自动模式下，所有消息都自动发送
+            else if (this.inAutoMode) {
+              if (this.ttsSettings.enabledInterruption) {
+                this.sendMessage();
+              } else if (!this.TTSrunning ||  !this.ttsSettings.enabled) {
+                this.sendMessage();
+              }
             }
           }
         } else {


### PR DESCRIPTION
feat(语音交互): 添加唤醒词与结束词组合模式

1. 添加一个模式： ”唤醒词与结束词“
2. 添加一个设置：”结束词“， 默认为“结束对话”
3. 模式为识别到唤醒词时开始自动发送所有消息（和自动模式完全一样），识别到结束词时停止， 重新开始识别唤醒词