### PR TITLE
fix(web_search): 修复搜索结果链接获取逻辑

### DIFF
--- a/py/web_search.py
+++ b/py/web_search.py
@@ -62,7 +62,16 @@ async def searxng_async(query):
 
             for result in soup.find_all('article', class_='result'):
                 title = result.find('h3').get_text() if result.find('h3') else 'No title'
-                link = result.find('a', class_='url_wrapper')['href'] if result.find('a', class_='url_wrapper') else 'No link'
+                
+                # 修复：使用正确的选择器
+                link_elem = result.find('a', class_='url_header')
+                if not link_elem:
+                    # 备用方案：从h3内的链接获取
+                    h3 = result.find('h3')
+                    link_elem = h3.find('a') if h3 else None
+                
+                link = link_elem['href'] if link_elem and link_elem.get('href') else 'No link'
+                
                 snippet = result.find('p', class_='content').get_text() if result.find('p', class_='content') else 'No snippet'
                 
                 results.append({


### PR DESCRIPTION
## searxng搜索链接丢失

searxng版本：SearXNG 2025.10.18-ee6d4f322

搜索时， 链接部分为"no link"

```json
{
    "title": "Qalculate! 计算器 使用杂记_qalculate教程-CSDN博客",
    "link": "No link",
    "snippet": "\n 推荐开源项目：Qalculate! GTK UI — 功能强大的跨平台计算器 项目介绍 Qalculate! 是一个全功能的桌面计算器，它以简单易用但又具备专业数学软件的复杂性和强大性为特点。不论是日常货币转换还是复杂的数值计算，Qalculate!\n "
}
```

修复后

```json
{
    "title": "Qalculate 开源项目教程 - CSDN博客",
    "link": "https://blog.csdn.net/gitblog_01113/article/details/141836739",
    "snippet": "\nQalculate 是一个多用途的跨平台桌面计算器，提供了一个强大的库（libqalculate）和 命令行 界面（CLI）。 它支持复杂的数学运算、单位转换、日期计算等功能，并且具有友好的用户界面和强大的解析能力。\n  "
}
```