### PR TITLE
Fix groupmemory bug

### DIFF
--- a/server.py
+++ b/server.py
@@ -1595,7 +1595,13 @@ async def _apply_group_memory_context(request: ChatRequest) -> dict:
     if memory_prompt:
         system_messages = [m for m in request.messages if m.get("role") == "system"]
         dialog_messages = [m for m in request.messages if m.get("role") != "system"]
-        request.messages = system_messages + [{"role": "system", "content": memory_prompt}] + dialog_messages
+        if system_messages:
+            merged_system = copy.deepcopy(system_messages[0])
+            merged_content = _extract_text_content(merged_system.get("content"))
+            merged_system["content"] = f"{merged_content}\n\n{memory_prompt}".strip() if merged_content else memory_prompt
+            request.messages = [merged_system] + dialog_messages
+        else:
+            request.messages = [{"role": "system", "content": memory_prompt}] + dialog_messages
     return {"enabled": memory_enabled, "group_id": group_id, "group": group, "memories": memories}
 
 async def _extract_group_memories(client, settings: dict, payload: dict) -> list[dict]:
@@ -1771,12 +1777,30 @@ async def _upsert_group_memories(group_id: str, source_chat_id: str, source_mess
 async def _invalidate_group_memories_by_chat(source_chat_id: str) -> None:
     if not source_chat_id:
         return
-    now_ts = int(time.time() * 1000)
     import aiosqlite
     async with aiosqlite.connect(COVS_PATH) as db:
         await db.execute(
-            "UPDATE group_memory SET status = 'deleted', updated_at = ? WHERE source_chat_id = ?",
-            (now_ts, source_chat_id),
+            "DELETE FROM group_memory WHERE source_chat_id = ?",
+            (source_chat_id,),
+        )
+        await db.commit()
+
+async def _invalidate_group_memories_by_group(group_id: str) -> None:
+    if not group_id:
+        return
+    import aiosqlite
+    async with aiosqlite.connect(COVS_PATH) as db:
+        await db.execute(
+            "DELETE FROM group_memory WHERE group_id = ?",
+            (group_id,),
+        )
+        await db.commit()
+
+async def _invalidate_all_group_memories() -> None:
+    import aiosqlite
+    async with aiosqlite.connect(COVS_PATH) as db:
+        await db.execute(
+            "DELETE FROM group_memory",
         )
         await db.commit()
 
@@ -6955,6 +6979,9 @@ class DeleteConversationRequest(BaseModel):
     conversation_id: Union[str, int, float]
     delete_memory: bool = False
 
+class ClearGroupMemoryRequest(BaseModel):
+    group_id: Union[str, int, float]
+
 @app.post("/api/group-memory/extract")
 async def extract_group_memory_endpoint(req: GroupMemoryExtractRequest):
     req.group_id = _normalize_entity_id(req.group_id)
@@ -6991,6 +7018,17 @@ async def delete_conversation_endpoint(req: DeleteConversationRequest):
     await save_covs(covs)
     if req.delete_memory:
         await _invalidate_group_memories_by_chat(req.conversation_id)
+    return {"success": True}
+
+@app.post("/api/group-memory/clear-group")
+async def clear_group_memory_endpoint(req: ClearGroupMemoryRequest):
+    req.group_id = _normalize_entity_id(req.group_id)
+    await _invalidate_group_memories_by_group(req.group_id)
+    return {"success": True}
+
+@app.post("/api/group-memory/clear-all")
+async def clear_all_group_memory_endpoint():
+    await _invalidate_all_group_memories()
     return {"success": True}
 
 from py.task_center import get_task_center

--- a/static/js/vue_methods.js
+++ b/static/js/vue_methods.js
@@ -723,6 +723,28 @@ let vue_methods = {
 
       this.conversations = this.conversations.filter(c => c.id !== conversationId);
     },
+    async clearGroupMemoriesByGroupId(groupId) {
+      const response = await fetch('/api/group-memory/clear-group', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          group_id: this.stringifyEntityId(groupId),
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('delete_failed');
+      }
+    },
+    async clearAllGroupMemories() {
+      const response = await fetch('/api/group-memory/clear-all', {
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        throw new Error('delete_failed');
+      }
+    },
     async clearAllHistoryRecords() {
       try {
         await this.$confirm(this.t('confirmClearAllHistory'), this.t('warning'), {
@@ -737,6 +759,7 @@ let vue_methods = {
             deleteMemory: true,
           });
         }
+        await this.clearAllGroupMemories();
 
         this.conversationId = null;
         this.messages = [{ id: Date.now() + Math.random(), role: 'system', content: this.system_prompt }];
@@ -797,13 +820,14 @@ let vue_methods = {
         .filter(conv => (conv.groupId || 'default') === groupId)
         .map(conv => conv.id);
 
-      for (const conversationId of groupConversationIds) {
-        await this.deleteConversationById(conversationId, {
-          deleteMemory: true,
-        });
-      }
+        for (const conversationId of groupConversationIds) {
+          await this.deleteConversationById(conversationId, {
+            deleteMemory: true,
+          });
+        }
+        await this.clearGroupMemoriesByGroupId(groupId);
 
-      this.conversationGroups = this.conversationGroups.filter(group => group.id !== groupId);
+        this.conversationGroups = this.conversationGroups.filter(group => group.id !== groupId);
 
       if (this.draftConversationGroupId === groupId) {
         this.draftConversationGroupId = 'default';
@@ -837,6 +861,7 @@ let vue_methods = {
             deleteMemory: true,
           });
         }
+        await this.clearGroupMemoriesByGroupId(groupId);
 
         if (this.conversationId === null) {
           this.messages = [{ id: Date.now() + Math.random(), role: 'system', content: this.system_prompt }];
@@ -10771,19 +10796,7 @@ async deleteGaussSceneOption(sceneId) {
 
 
   async confirmClearAll() {
-    try {
-      await this.$confirm(this.t('confirmClearAllHistory'), this.t('warning'), {
-        confirmButtonText: this.t('confirm'),
-        cancelButtonText: this.t('cancel'),
-        type: 'warning'
-      });
-      
-      this.conversations = [];
-      this.conversationId = null;
-      await this.saveConversations();
-    } catch (error) {
-      // 用户取消操作
-    }
+    await this.clearAllHistoryRecords();
   },
 
   async keepLastWeek() {


### PR DESCRIPTION
本次修改主要解决两类问题：

1.组内记忆注入到请求体时会生成第二条 system 消息，导致部分兼容 OpenAI 协议的服务返回 System message must be at the beginning，改为不再额外追加第二条 role: system，把组内记忆内容合并进原本的第一条 system prompt。
2.删除对话、清除组内对话、清空所有历史时，组内记忆没有被真正清除，导致旧记忆仍会在后续同组对话中被取回，通过 status = 'deleted' 做软删除改为直接从 group_memory 表物理删除

前端联动清理：
删除对话时可同步删组内记忆
“清除组内所有对话”会同步调用组记忆清理接口
“清空所有历史记录”会同步清空全部组内记忆，并把分组恢复为仅保留默认分组