### PR TITLE
fix(launch): eliminate FOUC on startup and smooth transition to main UI

### DIFF
--- a/main.js
+++ b/main.js
@@ -836,7 +836,7 @@ async function waitForBackend() {
       if (response.ok) {
         console.log('✨ 后端健康检查通过！');
         if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('backend-ready', { port: PORT });
+          mainWindow.webContents.send('backend-ready', { host: HOST, port: PORT });
         }
         return;
       }
@@ -1244,11 +1244,19 @@ app.whenReady().then(async () => {
     // 添加获取端口信息的 IPC 处理
     ipcMain.handle('get-server-info', () => {
       return {
+        host: HOST,
         port: PORT,
         defaultPort: DEFAULT_PORT,
         isDefaultPort: PORT === DEFAULT_PORT
       }
     })
+
+    // 骨架屏 fade-out 动画完成通知：仅触发一次，用于触发主进程加载主页面
+    let skeletonFadeoutDone;
+    ipcMain.once('skeleton-fadeout-done', () => {
+      console.log('✅ 骨架屏 fade-out 完成，开始加载主页面');
+      if (skeletonFadeoutDone) skeletonFadeoutDone();
+    });
 
     ipcMain.handle('set-env', async (event, arg) => {
       saveEnvVariable(arg.key, arg.value);
@@ -2014,6 +2022,13 @@ ipcMain.handle('upload-to-workspace', async (event, { targetDirPath, sourceFileP
       setTimeout(() => autoUpdater.quitAndInstall(), 500);
     });
             
+    // 等待骨架屏 fade-out 动画完成后再加载主页面，避免样式闪烁
+    // 兜底超时：若骨架屏异常未发送通知（如 preload 失败），最长等待 5s 后强制加载
+    await new Promise((resolve) => {
+      skeletonFadeoutDone = resolve;
+      setTimeout(() => resolve(), 5000);
+    });
+
     // 加载主页面
     await mainWindow.loadURL(`http://${HOST}:${PORT}`)
     ipcMain.on('set-language', (_, lang) => {

--- a/static/index.html
+++ b/static/index.html
@@ -1,8 +1,19 @@
 <!DOCTYPE html>
+<html class="loading">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Super Agent party</title>
+  <!-- FOUC 防护 + 主页面淡入：在外部 CSS 加载前隐藏 body，避免无样式内容闪烁 -->
+  <style>
+    html.loading body { opacity: 0; }
+    html.loading { background: #ffffff; }
+    /* 资源就绪后移除 loading 类时，body 从 opacity 0 平滑淡入到 1 */
+    html body {
+      opacity: 1;
+      transition: opacity 300ms ease-out;
+    }
+  </style>
   <link rel="manifest" href="manifest.json">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/transition.css">
@@ -18811,5 +18822,17 @@ function updateElement(el, rawMarkdown, formatFn) {
   <script src="js/vue_data.js"></script>
   <script src="js/vue_methods.js"></script>
   <script src="js/renderer.js"></script>
+  <script>
+    // FOUC 防护：CSS 解析完成/首次渲染就绪时，尽早移除 loading 类隐藏
+    // 使用 requestAnimationFrame 确保第一次渲染时机，比 window.load 更早触发
+    function onReady() {
+      document.documentElement.classList.remove('loading');
+    }
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+      onReady();
+    } else {
+      document.addEventListener('DOMContentLoaded', onReady);
+    }
+  </script>
 </body>
 </html>

--- a/static/js/preload.js
+++ b/static/js/preload.js
@@ -9,7 +9,7 @@ let vmcCfg = { receive:{enable:false,port:39539,syncExpression: false}, send:{en
 // 主进程推送最新配置
 ipcRenderer.on('vmc-config-changed', (_, cfg) => { vmcCfg = cfg; });
 
-// 与 main.js 保持一致的服务器配置
+// 与 main.js 保持一致的默认服务器配置（仅作 fallback，端口被占用时主进程会通过 backend-ready 推送真实值）
 const HOST = '127.0.0.1'
 const PORT = 3456
 // 获取从主进程传递的配置数据
@@ -23,17 +23,26 @@ contextBridge.exposeInMainWorld('electron', {
   ipcRenderer: {
     on: (channel, func) => {
       // 只允许特定的通道
-      const validChannels = ['backend-ready', 'trigger-search']; 
+      const validChannels = ['backend-ready', 'trigger-search'];
       if (validChannels.includes(channel)) {
         ipcRenderer.on(channel, (event, ...args) => func(...args));
       }
+    },
+    send: (channel, ...args) => {
+      // 仅允许骨架屏通知主进程动画完成
+      const validSendChannels = ['skeleton-fadeout-done'];
+      if (validSendChannels.includes(channel)) {
+        ipcRenderer.send(channel, ...args);
+      }
     }
   },
-  // 暴露服务器配置
+  // 暴露服务器配置（动态：backend-ready 推送前用默认值，推送后用真实值）
   server: {
     host: HOST,
     port: PORT
   },
+  // 同步获取服务器信息（host/port）
+  getServerInfo: () => ipcRenderer.invoke('get-server-info'),
   requestStopQQBot: () => ipcRenderer.invoke('request-stop-qqbot'),
   requestStopFeishuBot : () => ipcRenderer.invoke('request-stop-feishubot'),
   requestStopWechatBot : () => ipcRenderer.invoke('request-stop-wechatbot'),

--- a/static/skeleton.html
+++ b/static/skeleton.html
@@ -178,8 +178,6 @@
       0%, 100% { transform: translateY(0); }
       50% { transform: translateY(-12px); }
     }
-
-    #preload-frame { display: none; }
   </style>
 </head>
 <body>
@@ -204,8 +202,6 @@
       </div>
       <div class="loading-label" id="status-text">Initializing</div>
     </div>
-    
-    <iframe id="preload-frame"></iframe>
   </div>
 
   <script>
@@ -247,7 +243,28 @@
 
     // 3. 监听后端准备就绪信号
     if (ipcRenderer) {
-      ipcRenderer.on('backend-ready', () => {
+      ipcRenderer.on('backend-ready', (event, payload) => {
+        const { host, port } = payload;
+        const base = `http://${host}:${port}`;
+
+        // 预热主页面关键 CSS 资源到 HTTP 缓存
+        // 这样主进程 loadURL 时浏览器本地命中缓存，几乎瞬时呈现
+        const warmUrls = [
+          '/css/styles.css',
+          '/css/transition.css',
+          '/libs/element-plus.css',
+          '/fontawesome/css/all.min.css',
+          '/css/github-markdown.min.css',
+          '/css/github.min.css',
+          '/libs/driver.css',
+          '/libs/katex.min.css',
+        ];
+        warmUrls.forEach(url => {
+          // 用 fetch 触发真实 HTTP 请求，把响应写入浏览器 HTTP 缓存
+          // 不需要 await，让它并行预热即可
+          fetch(base + url, { cache: 'force-cache' }).catch(() => {});
+        });
+
         // [关键修复]：清理所有定时器和动画循环
         clearInterval(simulateLoad);
         clearInterval(textInterval);
@@ -258,22 +275,18 @@
         statusText.innerText = "Ready";
         statusText.style.color = "#000";
 
-        // 开始加载主页面
-        const { host, port } = window.electron.server;
-        const mainPageUrl = `http://${host}:${port}`;
-        
-        const preloadFrame = document.getElementById('preload-frame');
-        preloadFrame.src = mainPageUrl;
-        
-        preloadFrame.onload = function() {
-          // 稍微延迟一下，让用户看清 100% 和 Ready
+        // 主进程将在收到 skeleton-fadeout-done 后由主进程的 loadURL 加载主页面
+        // 这里仅负责播放 fade-out 动画并通知主进程动画完成，避免双重导航竞态导致 FOUC
+        // 稍微延迟一下，让用户看清 100% 和 Ready
+        setTimeout(() => {
+          document.getElementById('app').classList.add('fade-out');
           setTimeout(() => {
-            document.getElementById('app').classList.add('fade-out');
-            setTimeout(() => {
-              window.location.href = mainPageUrl;
-            }, 600);
-          }, 400);
-        };
+            // 通知主进程：骨架屏动画结束，可以加载主页面了
+            if (window.electron && window.electron.ipcRenderer && window.electron.ipcRenderer.send) {
+              window.electron.ipcRenderer.send('skeleton-fadeout-done');
+            }
+          }, 600);
+        }, 400);
       });
     }
   </script>

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,21 +1,81 @@
-const CACHE_NAME = 'my-pwa-cache-v1';
-const urlsToCache = [
+// Super Agent Party Service Worker
+// 缓存关键静态资源，第二次启动时主页面与 CSS 走 SW 缓存秒开
+const CACHE_NAME = 'sap-cache-v1';
+
+// 关键渲染资源（首次安装时预缓存）
+const PRECACHE_URLS = [
   '/',
-  '/index.html',           
-  '/css/style.css',               
-  '/source/icon.png'   
+  '/index.html',
+  '/manifest.json',
+  '/css/styles.css',
+  '/css/transition.css',
+  '/libs/element-plus.css',
+  '/fontawesome/css/all.min.css',
+  '/css/github-markdown.min.css',
+  '/css/github.min.css',
+  '/libs/driver.css',
+  '/libs/katex.min.css',
+  '/source/icon.png'
 ];
 
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(urlsToCache))
+      .then(cache => cache.addAll(PRECACHE_URLS).catch(err => {
+        // 单个资源失败不应阻塞整个 install
+        console.warn('[SW] precache partial fail:', err);
+      }))
+      .then(() => self.skipWaiting())
   );
 });
 
-self.addEventListener('fetch', event => {
-  event.respondWith(
-    caches.match(event.request)
-      .then(response => response || fetch(event.request))
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    ).then(() => self.clients.claim())
   );
+});
+
+// 缓存策略：CSS/JS/图片等静态资源用 stale-while-revalidate；
+// HTML 主文档用 network-first（保证更新及时）
+self.addEventListener('fetch', event => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+
+  const url = new URL(req.url);
+  // 仅对同源请求应用 SW 缓存策略
+  if (url.origin !== self.location.origin) return;
+
+  const isHTML = (req.destination === 'document') || url.pathname.endsWith('.html') || url.pathname === '/';
+  const isStaticAsset = /\.(?:css|js|png|jpg|jpeg|svg|gif|webp|woff2?|ttf|eot)$/.test(url.pathname);
+
+  if (isHTML) {
+    // network-first：保证主文档及时更新
+    event.respondWith(
+      fetch(req).then(res => {
+        const copy = res.clone();
+        caches.open(CACHE_NAME).then(c => c.put(req, copy)).catch(() => {});
+        return res;
+      }).catch(() => caches.match(req).then(r => r || Response.error()))
+    );
+    return;
+  }
+
+  if (isStaticAsset) {
+    // stale-while-revalidate：先返回缓存，后台再异步更新
+    event.respondWith(
+      caches.match(req).then(cached => {
+        const network = fetch(req).then(res => {
+          if (res && res.status === 200) {
+            const copy = res.clone();
+            caches.open(CACHE_NAME).then(c => c.put(req, copy)).catch(() => {});
+          }
+          return res;
+        }).catch(() => cached);
+        return cached || network;
+      })
+    );
+    return;
+  }
 });


### PR DESCRIPTION
- main.js: backend-ready now carries host+port; loadURL waits for 'skeleton-fadeout-done' IPC (with 5s timeout fallback) to remove the dual-navigation race between skeleton redirect and main process loadURL that caused the flash of unstyled content.
- preload.js: expose ipcRenderer.send('skeleton-fadeout-done') channel and getServerInfo helper so the skeleton uses real host/port.
- skeleton.html: drop the iframe preload + window.location.href redirect pattern; on backend-ready, fetch-prefetch the 8 critical CSS files to warm Electron's HTTP cache, then fade out and notify the main process.
- index.html: add <html class='loading'> with inline FOUC guard CSS, 300ms ease-out opacity transition on body, and remove 'loading' on DOMContentLoaded (CSS is guaranteed ready there) so the main UI fades in cleanly instead of flashing unstyled DOM.
- sw.js: rewrite the Service Worker. The old one precached the wrong path ('/css/style.css' does not exist) and lacked an activate handler; the new one precaches the real critical CSS, uses network-first for HTML docs and stale-while-revalidate for static assets, and calls skipWaiting/clients.claim to speed up second launches.