### PR TITLE
feat: add You.com Search API integration

### DIFF
--- a/config/settings_template.json
+++ b/config/settings_template.json
@@ -145,6 +145,8 @@
       "serper_api_key": "",
       "bochaai_max_results":10,
       "bochaai_api_key": "",
+      "youcom_max_results":10,
+      "youcom_api_key": "",
       "firecrawl_url": "https://api.firecrawl.dev/v2",
       "firecrawl_api_key": "",
       "firecrawl_mode": "scrape"

--- a/py/web_search.py
+++ b/py/web_search.py
@@ -1018,3 +1018,82 @@ markdown_new_tool = {
         },
     },
 }
+
+# ========== You.com Search ==========
+
+async def youcom_search(query):
+    """
+    通过 You.com Search API 获取网络搜索结果。
+    API文档: https://you.com/specs/openapi_search_v1.yaml
+    """
+    settings = await load_settings()
+    def sync_search():
+        max_results = settings['webSearch'].get('youcom_max_results', 10)
+        api_key = settings['webSearch'].get('youcom_api_key', "")
+
+        if not api_key:
+            return "API key未配置，请检查设置中的 YDC_API_KEY"
+
+        url = "https://ydc-index.io/v1/search"
+        headers = {
+            'X-API-Key': api_key,
+            'Content-Type': 'application/json'
+        }
+        payload = json.dumps({
+            "query": query,
+            "count": max_results
+        })
+
+        try:
+            response = requests.post(url, headers=headers, data=payload, timeout=30)
+            if response.status_code == 200:
+                result_data = response.json()
+
+                formatted_results = []
+                web_results = result_data.get('results', {}).get('web', [])
+
+                for item in web_results:
+                    formatted_item = {
+                        'title': item.get('title', '无标题'),
+                        'link': item.get('url', ''),
+                        'displayUrl': item.get('url', ''),
+                        'snippet': item.get('description') or (item.get('snippets', [''])[0] if item.get('snippets') else '无内容摘要'),
+                        'siteName': item.get('title', '未知来源'),
+                    }
+                    formatted_results.append(formatted_item)
+
+                return json.dumps(formatted_results, indent=2, ensure_ascii=False)
+            elif response.status_code == 401:
+                return f"You.com API key无效或已过期，状态码：{response.status_code}"
+            elif response.status_code == 403:
+                return f"You.com API key缺少所需权限，状态码：{response.status_code}"
+            else:
+                return f"请求失败，状态码：{response.status_code}，响应内容：{response.text}"
+        except Exception as e:
+            print(f"You.com搜索错误: {str(e)}")
+            return ""
+
+    try:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, sync_search)
+    except Exception as e:
+        print(f"异步执行错误: {e}")
+        return ""
+
+youcom_tool = {
+    "type": "function",
+    "function": {
+        "name": "youcom_search",
+        "description": "通过You.com Search API获取网络信息，返回带有摘要和来源的搜索结果。",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "需要搜索的关键词或自然语言查询语句。",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+}

--- a/server.py
+++ b/server.py
@@ -19,10 +19,10 @@ from py.ws_manager import ws_manager
 # === Pre-load heavy tool modules at startup to avoid blocking first request ===
 from py.web_search import (
     DDGsearch, searxng, Tavily_search, Google_search,
-    Brave_search, Exa_search, Serper_search, bochaai_search,
+    Brave_search, Exa_search, Serper_search, bochaai_search, youcom_search,
     jina_crawler, Crawl4Ai_search, firecrawl_search, simple_fetch, markdown_new,
     duckduckgo_tool, searxng_tool, tavily_tool, google_tool,
-    brave_tool, exa_tool, serper_tool, bochaai_tool,
+    brave_tool, exa_tool, serper_tool, bochaai_tool, youcom_tool,
     jina_crawler_tool, simple_fetch_tool, Crawl4Ai_tool, firecrawl_tool, markdown_new_tool,
 )
 from py.know_base import kb_tool, query_knowledge_base, rerank_knowledge_base
@@ -1229,6 +1229,7 @@ async def dispatch_tool(tool_name: str, tool_params: dict, settings: dict,is_sub
         "Exa_search": Exa_search,
         "Serper_search": Serper_search,
         "bochaai_search": bochaai_search,
+        "youcom_search": youcom_search,
         "comfyui_tool_call": comfyui_tool_call,
         "time": time,
         "get_weather": get_weather,
@@ -4116,6 +4117,8 @@ async def generate_stream_response(client, reasoner_client, request: ChatRequest
                             results = await Serper_search(user_prompt)
                         elif settings['webSearch']['engine'] == 'bochaai':
                             results = await bochaai_search(user_prompt)
+                        elif settings['webSearch']['engine'] == 'youcom':
+                            results = await youcom_search(user_prompt)
                         if results:
                             content_append(request.messages, 'user',  f"\n\n联网搜索结果：{results}\n\n")
                             tool_chunk = {
@@ -4143,6 +4146,8 @@ async def generate_stream_response(client, reasoner_client, request: ChatRequest
                             tools.append(serper_tool)
                         elif settings['webSearch']['crawler'] == 'bochaai':
                             tools.append(bochaai_tool)
+                        elif settings['webSearch']['crawler'] == 'youcom':
+                            tools.append(youcom_tool)
 
                         if settings['webSearch']['crawler'] == 'jina':
                             tools.append(jina_crawler_tool)
@@ -6162,6 +6167,8 @@ async def generate_complete_response(client,reasoner_client, request: ChatReques
                     results = await Serper_search(user_prompt)
                 elif settings['webSearch']['engine'] == 'bochaai':
                     results = await bochaai_search(user_prompt)
+                elif settings['webSearch']['engine'] == 'youcom':
+                    results = await youcom_search(user_prompt)
                 if results:
                     content_append(request.messages, 'user',  f"\n\n联网搜索结果：{results}")
             if settings['webSearch']['when'] == 'after_thinking' or settings['webSearch']['when'] == 'both':
@@ -6181,6 +6188,8 @@ async def generate_complete_response(client,reasoner_client, request: ChatReques
                     tools.append(serper_tool)
                 elif settings['webSearch']['crawler'] == 'bochaai':
                     tools.append(bochaai_tool)
+                elif settings['webSearch']['crawler'] == 'youcom':
+                    tools.append(youcom_tool)
 
                 if settings['webSearch']['crawler'] == 'jina' and not _is_steam_build:
                     tools.append(jina_crawler_tool)

--- a/static/index.html
+++ b/static/index.html
@@ -10788,6 +10788,7 @@ function updateElement(el, rawMarkdown, formatFn) {
                           <el-option label="Exa" value="exa" ></el-option>
                           <el-option label="Serper" value="serper" ></el-option>
                           <el-option label="Bochaai" value="bochaai" ></el-option>
+                          <el-option label="You.com" value="youcom" ></el-option>
                         </el-select>
                       </el-form-item>
                       <el-form-item :label="t('webCrawling')" class="form-item-align">
@@ -11168,6 +11169,50 @@ function updateElement(el, rawMarkdown, formatFn) {
                       <el-form-item :label="t('apiKey')" class="form-item-align">
                         <el-input
                           v-model="webSearchSettings.bochaai_api_key"
+                          :placeholder="t('apiKeyPlaceholder')"
+                          show-password
+                          @input="autoSaveSettings"
+                          class="full-width-input"
+                        />
+                      </el-form-item>
+                    </div>
+                  </div>
+                  <!-- You.com 配置块 -->
+                  <div class="tool-item" v-show="webSearchSettings.engine === 'youcom'">
+                    <div class="tool-header">
+                      <div class="header-left">
+                        <span>
+                          <el-icon>
+                            <i class="fa-solid fa-globe"></i>
+                          </el-icon>
+                          You.com
+                          <el-link
+                            type="primary"
+                            :underline="false"
+                            href="https://api.you.com"
+                            target="_blank"
+                          >
+                            <el-icon class="mr-1">
+                              <i class="fa-solid fa-key"></i>
+                            </el-icon>{{ t('gotoAPI') }}
+                          </el-link>
+                        </span>
+                      </div>
+                    </div>
+                    <div class="tool-content">
+                      <el-form-item :label="t('resultCount')" class="form-item-align">
+                        <el-slider
+                          v-model="webSearchSettings.youcom_max_results"
+                          :min="1"
+                          :max="20"
+                          :step="1"
+                          show-input
+                          @input="autoSaveSettings"
+                        />
+                      </el-form-item>
+                      <el-form-item :label="t('apiKey')" class="form-item-align">
+                        <el-input
+                          v-model="webSearchSettings.youcom_api_key"
                           :placeholder="t('apiKeyPlaceholder')"
                           show-password
                           @input="autoSaveSettings"

--- a/static/js/vue_data.js
+++ b/static/js/vue_data.js
@@ -375,6 +375,8 @@ let vue_data = {
       serper_api_key: '',
       bochaai_max_results:10,
       bochaai_api_key: '',
+      youcom_max_results: 10,
+      youcom_api_key: '',
       firecrawl_url: 'https://api.firecrawl.dev/v2', // 官方API或自部署地址
       firecrawl_api_key: '',
       firecrawl_mode: 'scrape', 
@@ -549,6 +551,7 @@ let vue_data = {
       tavilyConfig: true,
       jinaConfig: true,
       Crawl4AiConfig: true,
+      youcomConfig: true,
       settingsAdvanced: true,
       reasonerAdvanced: true,
       knowledgeAdvanced: false,


### PR DESCRIPTION
## Summary

Add You.com Search API as a selectable web search engine for agents in super-agent-party.

## Changes

- **`py/web_search.py`** — `youcom_search(query)` async function + `youcom_tool` OpenAI function-calling definition
- **`server.py`** — wire `youcom_search` into `_TOOL_HOOKS` and search engine dispatch; register `youcom_tool` for LLM tool selection
- **`config/settings_template.json`** — `youcom_api_key` and `youcom_max_results` settings

## How It Works
Agents can use You.com Search when `webSearch.engine` is set to `youcom` in settings. The function POSTs to `https://ydc-index.io/v1/search` with `X-API-Key` authentication, parses `results.web[]` into `{title, link, displayUrl, snippet, siteName}`, then passes results to the LLM.

## Validation
Run the app with `youcom_api_key` configured in settings and `webSearch.engine` set to `youcom` — agents will use You.com Search for web queries.

## Notes
- Uses `X-API-Key` header (not `Authorization: Bearer`) per the [You.com OpenAPI spec](https://you.com/specs/openapi_search_v1.yaml)
- API key is read from settings (`webSearch.youcom_api_key`), consistent with how other search engines are configured
- Gracefully degrades: missing key returns an error message; API errors return localized messages; network failures return empty string