### PR TITLE
Add MiniMax Anthropic-compatible provider route

### DIFF
--- a/static/js/vue_methods.js
+++ b/static/js/vue_methods.js
@@ -1120,6 +1120,7 @@ formatFileUrl(originalUrl) {
               "siliconflow": "https://api.siliconflow.cn/",
               "ZhipuAI":"https://open.bigmodel.cn/api/anthropic/",
               "moonshot":"https://api.moonshot.cn/anthropic/",
+              "minimax":"https://api.minimaxi.com/anthropic/",
               "aliyun": "https://dashscope.aliyuncs.com/apps/anthropic/",
               "modelscope":"https://api-inference.modelscope.cn/",
               "302.AI":"https://api.302.ai/cc/",
@@ -5666,6 +5667,7 @@ formatMessage(content, index) {
         "siliconflow": "https://api.siliconflow.cn/",
         "ZhipuAI":"https://open.bigmodel.cn/api/anthropic/",
         "moonshot":"https://api.moonshot.cn/anthropic/",
+        "minimax":"https://api.minimaxi.com/anthropic/",
         "aliyun": "https://dashscope.aliyuncs.com/apps/anthropic/",
         "modelscope":"https://api-inference.modelscope.cn/",
         "302.AI":"https://api.302.ai/cc/"


### PR DESCRIPTION
Reason: MiniMax has an OpenAI-compatible preset but no Anthropic-compatible route, so its Claude Code base URL wrongly fell back to the plain /v1 OpenAI URL.

### What changed
- Added a MiniMax entry to the Anthropic-compatible provider URL map in `syncProviderConfig` (`static/js/vue_methods.js`) so Claude Code sync resolves the correct Anthropic endpoint instead of the OpenAI `/v1` fallback.
- Added the same MiniMax entry to the Anthropic-compatible provider URL map in `selectCCProvider` (`static/js/vue_methods.js`), keeping both maps consistent.

The Anthropic base URL (`https://api.minimaxi.com/anthropic/`) matches the region already used by the existing MiniMax OpenAI-compatible preset and follows the trailing-slash style of the surrounding entries.

### Checks
- `npm test` (`node scripts/smoke-check.js`) — JSON parsed and JavaScript files compiled successfully.
