### PR TITLE
fix: strip event handler attributes in formatMessage tag filter

### DIFF
--- a/static/js/vue_methods.js
+++ b/static/js/vue_methods.js
@@ -1455,7 +1455,8 @@ formatMessage(content, index) {
         if (lowerTagName === 'think') return match;
         const isStandardHtmlName = /^[a-zA-Z][a-zA-Z0-9-]*$/.test(tagName);
         if (isStandardHtmlName) {
-          return match;
+          const safeAttrs = attrs.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi, '');
+          return `<${slash}${tagName}${safeAttrs}>`;
         } else {
           return '';
         }


### PR DESCRIPTION
The anyTagRegex filter in formatMessage() checks tag names but passes attributes through unchanged. This allows event handlers (onerror, onload, ontoggle) on allowlisted tags like <img> and <svg> to reach v-html, enabling XSS via crafted LLM output or MCP tool responses.

Strip on* attributes from preserved tags before rendering.
fix #882 